### PR TITLE
Enable caller to abort store query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- If the `callback` function passed to`WakuStore.queryHistory` returns `true`, then no further pages are retrieved from the store.
+
 ### Changed
 - **Breaking**: Renamed `WakuStore.QueryOptions`'s `direction` to `pageDirection` (and its type) as it only affects the page ordering,
   not the ordering of messages with the page.


### PR DESCRIPTION
If the `callback` function passed to`WakuStore.queryHistory` returns
`true`, then no further pages are retrieved from the store.