### PR TITLE
Release Candidate 0.14.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.13.1",
+  "version": "0.14.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.13.1",
+      "version": "0.14.0-rc.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.13.1",
+  "version": "0.14.0-rc.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- If the `callback` function passed to`WakuStore.queryHistory` returns
  `true`, then no further pages are retrieved from the store.
- Use webpack to build UMD bundle of the library.

### Changed
- **Breaking**: Renamed `WakuStore.QueryOptions`'s `direction` to
  `pageDirection` (and its type) as it only affects the page ordering,
  not the ordering of messages with the page.

### Fixed
- Docs: Ensure that `WakuStore`'s `QueryOptions` documentation is
  available [online](https://status-im.github.io/js-waku/docs/).