### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2021-10-13
+
 ### Added
 - If the `callback` function passed to`WakuStore.queryHistory` returns `true`, then no further pages are retrieved from the store.
 - Use webpack to build UMD bundle of the library, see [README](./README.md) for usage.
@@ -246,7 +248,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/status-im/js-waku/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/status-im/js-waku/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/status-im/js-waku/compare/v0.12.0...v0.13.0
 [0.12.2]: https://github.com/status-im/js-waku/compare/v0.12.1...v0.12.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.14.0-rc.0",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.14.0-rc.0",
+      "version": "0.14.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.14.0-rc.0",
+  "version": "0.14.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- If the `callback` function passed to`WakuStore.queryHistory` returns `true`, then no further pages are retrieved from the store.
- Use webpack to build UMD bundle of the library, see [README](./README.md) for usage.

### Changed
- **Breaking**: Renamed `WakuStore.QueryOptions`'s `direction` to `pageDirection` (and its type) as it only affects the page ordering,
  not the ordering of messages with the page.

### Fixed
- Docs: Ensure that `WakuStore`'s `QueryOptions` documentation is available [online](https://status-im.github.io/js-waku/docs/).