### PR TITLE
feat: add `observers` to the `IRelay` interface for public access

### DIFF
--- a/packages/core/src/lib/relay/index.ts
+++ b/packages/core/src/lib/relay/index.ts
@@ -15,7 +15,7 @@ import type {
   ProtocolCreateOptions,
   SendResult,
 } from "@waku/interfaces";
-import { IDecodedMessage } from "@waku/interfaces";
+import { IDecodedMessage, Observer } from "@waku/interfaces";
 import debug from "debug";
 
 import { DefaultPubSubTopic } from "../constants.js";
@@ -25,11 +25,6 @@ import { pushOrInitMapSet } from "../push_or_init_map.js";
 import * as constants from "./constants.js";
 
 const log = debug("waku:relay");
-
-export type Observer<T extends IDecodedMessage> = {
-  decoder: IDecoder<T>;
-  callback: Callback<T>;
-};
 
 export type RelayCreateOptions = ProtocolCreateOptions & GossipsubOpts;
 

--- a/packages/interfaces/src/relay.ts
+++ b/packages/interfaces/src/relay.ts
@@ -8,11 +8,17 @@ import type {
 } from "./message.js";
 import type { Callback, SendResult } from "./protocols.js";
 
+export type Observer<T extends IDecodedMessage> = {
+  decoder: IDecoder<T>;
+  callback: Callback<T>;
+};
+
 export interface IRelay extends GossipSub {
   send: (encoder: IEncoder, message: IMessage) => Promise<SendResult>;
   addObserver: <T extends IDecodedMessage>(
     decoder: IDecoder<T>,
     callback: Callback<T>
   ) => () => void;
+  observers: Map<string, Set<Observer<any>>>;
   getMeshPeers: () => string[];
 }


### PR DESCRIPTION
## Problem

waku.relay (IRelay) does not provide public accessor for observers.

## Solution

add it to the `IRelay` interface

## Notes

- Resolves https://github.com/orgs/waku-org/projects/2/views/1?pane=issue&itemId=19315766
