### PR TITLE
fix: eslint errors

### DIFF
--- a/ci/publish.js
+++ b/ci/publish.js
@@ -1,8 +1,12 @@
+import cp from "child_process";
 import fs from "fs";
 import path from "path";
-import cp from "child_process";
-import { promisify } from "util";
 import { fileURLToPath } from "url";
+import { promisify } from "util";
+
+import debug from "debug";
+
+const log = debug("waku:ci:publish");
 
 const PACKAGE_JSON = "package.json";
 // hack to get __dirname
@@ -13,10 +17,10 @@ const readFile = promisify(fs.readFile);
 
 run()
   .then(() => {
-    console.info("Successfully published packages.");
+    log("Successfully published packages.");
   })
   .catch((err) => {
-    console.error("Failed at publishing packages with ", err.message);
+    log("Failed at publishing packages with ", err.message);
   });
 
 async function run() {
@@ -44,11 +48,11 @@ async function run() {
           await exec(
             `npm publish --workspace ${info.workspace} --tag latest --access public`
           );
-          console.info(
+          log(
             `Successfully published ${info.name} with version ${info.version}.`
           );
         } catch (err) {
-          console.error(
+          log(
             `Cannot publish ${info.workspace} with version ${info.version}. Error: ${err.message}`
           );
         }
@@ -76,7 +80,7 @@ async function readWorkspace(packagePath) {
 
 async function shouldBePublished(info) {
   if (info.private) {
-    console.info(`Skipping ${info.path} because it is private.`);
+    log(`Skipping ${info.path} because it is private.`);
     return false;
   }
 
@@ -88,13 +92,13 @@ async function shouldBePublished(info) {
       return true;
     }
 
-    console.info(`Workspace ${info.path} is already published.`);
+    log(`Workspace ${info.path} is already published.`);
   } catch (err) {
     if (err.message.includes("code E404")) {
       return true;
     }
 
-    console.error(
+    log(
       `Cannot check published version of ${info.path}. Received error: ${err.message}`
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "packages/tests",
         "packages/build-utils"
       ],
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
       "devDependencies": {
         "@size-limit/preset-big-lib": "^8.2.4",
         "gh-pages": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "*.{ts,json,js,md,cjs}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "debug": "^4.3.4"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,90 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.13](https://github.com/waku-org/js-waku/compare/core-v0.0.12...core-v0.0.13) (2023-03-24)
 
-
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
-
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
 
 ### Bug Fixes
 
-* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -7,78 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/dns-discovery bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/dns-discovery bumped from 0.0.8 to 0.0.9
 
 ## [0.0.9](https://github.com/waku-org/js-waku/compare/create-v0.0.8...create-v0.0.9) (2023-03-24)
 
-
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from 0.0.12 to 0.0.13
-    * @waku/dns-discovery bumped from 0.0.7 to 0.0.8
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from 0.0.12 to 0.0.13
+    - @waku/dns-discovery bumped from 0.0.7 to 0.0.8
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
 
 ## [0.0.8](https://github.com/waku-org/js-waku/compare/create-v0.0.7...create-v0.0.8) (2023-03-23)
 
-
 ### Bug Fixes
 
-* @waku/create should not depend on @waku/peer-exchange ([f0ac886](https://github.com/waku-org/js-waku/commit/f0ac886593a96a7d63f75b481d0c2419c1084cda))
-
+- @waku/create should not depend on @waku/peer-exchange ([f0ac886](https://github.com/waku-org/js-waku/commit/f0ac886593a96a7d63f75b481d0c2419c1084cda))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from 0.0.11 to 0.0.12
-    * @waku/dns-discovery bumped from 0.0.6 to 0.0.7
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from 0.0.11 to 0.0.12
+    - @waku/dns-discovery bumped from 0.0.6 to 0.0.7
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.7](https://github.com/waku-org/js-waku/compare/create-v0.0.6...create-v0.0.7) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* bump typescript
-* bump libp2p dependencies
+- bump typescript
+- bump libp2p dependencies
 
 ### Features
 
-* DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
-
+- DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from * to 0.0.11
-    * @waku/dns-discovery bumped from * to 0.0.6
-    * @waku/peer-exchange bumped from * to 0.0.4
-  * devDependencies
-    * @waku/interfaces bumped from * to 0.0.8
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from \* to 0.0.11
+    - @waku/dns-discovery bumped from \* to 0.0.6
+    - @waku/peer-exchange bumped from \* to 0.0.4
+  - devDependencies
+    - @waku/interfaces bumped from \* to 0.0.8
 
 ## [Unreleased]
 

--- a/packages/dns-discovery/CHANGELOG.md
+++ b/packages/dns-discovery/CHANGELOG.md
@@ -7,67 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from 0.0.6 to 0.0.7
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from 0.0.6 to 0.0.7
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from 0.0.7 to 0.0.8
-    * @waku/utils bumped from 0.0.2 to 0.0.3
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from 0.0.7 to 0.0.8
+    - @waku/utils bumped from 0.0.2 to 0.0.3
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from 0.0.8 to 0.0.9
 
 ## [0.0.6](https://github.com/waku-org/js-waku/compare/dns-discovery-v0.0.5...dns-discovery-v0.0.6) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* directly convert from ENR to `PeerInfo`, remove unneeded utility
-* extract decoder code
-* bump typescript
-* bump libp2p dependencies
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- directly convert from ENR to `PeerInfo`, remove unneeded utility
+- extract decoder code
+- bump typescript
+- bump libp2p dependencies
 
 ### Features
 
-* Add mocha to dns-discovery ([#1154](https://github.com/waku-org/js-waku/issues/1154)) ([f945eb9](https://github.com/waku-org/js-waku/commit/f945eb90c49bb54322c4cb58c20cfdeee72ff4f2))
-* DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
-
+- Add mocha to dns-discovery ([#1154](https://github.com/waku-org/js-waku/issues/1154)) ([f945eb9](https://github.com/waku-org/js-waku/commit/f945eb90c49bb54322c4cb58c20cfdeee72ff4f2))
+- DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
 
 ### Bug Fixes
 
-* **dns-discovery/peer-exchange:** Check if peer is already tagged ([952aadd](https://github.com/waku-org/js-waku/commit/952aadd7bbbe1a7265c5126c1678f552bef0648d))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-
+- **dns-discovery/peer-exchange:** Check if peer is already tagged ([952aadd](https://github.com/waku-org/js-waku/commit/952aadd7bbbe1a7265c5126c1678f552bef0648d))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
-* Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
+- Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from * to 0.0.6
-    * @waku/utils bumped from * to 0.0.2
-  * devDependencies
-    * @waku/interfaces bumped from * to 0.0.8
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from \* to 0.0.6
+    - @waku/utils bumped from \* to 0.0.2
+  - devDependencies
+    - @waku/interfaces bumped from \* to 0.0.8
 
 ## [Unreleased]
 

--- a/packages/enr/CHANGELOG.md
+++ b/packages/enr/CHANGELOG.md
@@ -7,61 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/utils bumped from 0.0.2 to 0.0.3
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/utils bumped from 0.0.2 to 0.0.3
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
 
 ## [0.0.9](https://github.com/waku-org/js-waku/compare/enr-v0.0.8...enr-v0.0.9) (2023-03-28)
 
-
 ### Bug Fixes
 
-* Ensure that websocket multiaddrs are returned from ENR ([#1275](https://github.com/waku-org/js-waku/issues/1275)) ([9494041](https://github.com/waku-org/js-waku/commit/94940411b0fd525044765b9068068ddf274eba2f)), closes [#1271](https://github.com/waku-org/js-waku/issues/1271)
+- Ensure that websocket multiaddrs are returned from ENR ([#1275](https://github.com/waku-org/js-waku/issues/1275)) ([9494041](https://github.com/waku-org/js-waku/commit/94940411b0fd525044765b9068068ddf274eba2f)), closes [#1271](https://github.com/waku-org/js-waku/issues/1271)
 
 ## [0.0.6](https://github.com/waku-org/js-waku/compare/enr-v0.0.5...enr-v0.0.6) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* directly convert from ENR to `PeerInfo`, remove unneeded utility
-* extract encoder code
-* extract decoder code
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- directly convert from ENR to `PeerInfo`, remove unneeded utility
+- extract encoder code
+- extract decoder code
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
-* Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
-* Extract encoder code ([22ffcf5](https://github.com/waku-org/js-waku/commit/22ffcf571aa3998267f0f3b59576abc38f3f4281))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
+- Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
+- Extract encoder code ([22ffcf5](https://github.com/waku-org/js-waku/commit/22ffcf571aa3998267f0f3b59576abc38f3f4281))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/utils bumped from * to 0.0.2
-  * devDependencies
-    * @waku/interfaces bumped from * to 0.0.8
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/utils bumped from \* to 0.0.2
+  - devDependencies
+    - @waku/interfaces bumped from \* to 0.0.8
 
 ## [Unreleased]
 

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -7,62 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.10](https://github.com/waku-org/js-waku/compare/interfaces-v0.0.9...interfaces-v0.0.10) (2023-03-24)
 
-
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ## [0.0.9](https://github.com/waku-org/js-waku/compare/interfaces-v0.0.8...interfaces-v0.0.9) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ## [0.0.8](https://github.com/waku-org/js-waku/compare/interfaces-v0.0.7...interfaces-v0.0.8) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* directly convert from ENR to `PeerInfo`, remove unneeded utility
-* extract encoder code
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- directly convert from ENR to `PeerInfo`, remove unneeded utility
+- extract encoder code
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
-* Extract encoder code ([22ffcf5](https://github.com/waku-org/js-waku/commit/22ffcf571aa3998267f0f3b59576abc38f3f4281))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
+- Extract encoder code ([22ffcf5](https://github.com/waku-org/js-waku/commit/22ffcf571aa3998267f0f3b59576abc38f3f4281))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ## [Unreleased]
 

--- a/packages/message-encryption/CHANGELOG.md
+++ b/packages/message-encryption/CHANGELOG.md
@@ -7,58 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from 0.0.11 to 0.0.12
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from 0.0.11 to 0.0.12
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from 0.0.12 to 0.0.13
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from 0.0.12 to 0.0.13
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.10](https://github.com/waku-org/js-waku/compare/message-encryption-v0.0.9...message-encryption-v0.0.10) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update message.proto: payload and content topic are always defined
-* bump typescript
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update message.proto: payload and content topic are always defined
+- bump typescript
 
 ### Features
 
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from * to 0.0.11
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from \* to 0.0.11
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/peer-exchange/CHANGELOG.md
+++ b/packages/peer-exchange/CHANGELOG.md
@@ -2,84 +2,77 @@
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from 0.0.12 to 0.0.13
-    * @waku/enr bumped from 0.0.7 to 0.0.8
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from * to 0.0.3
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from 0.0.12 to 0.0.13
+    - @waku/enr bumped from 0.0.7 to 0.0.8
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from \* to 0.0.3
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from 0.0.8 to 0.0.9
 
 ## [0.0.5](https://github.com/waku-org/js-waku/compare/peer-exchange-v0.0.4...peer-exchange-v0.0.5) (2023-03-23)
 
-
 ### Features
 
-* Compliance test for peer-exchange discovery ([#1186](https://github.com/waku-org/js-waku/issues/1186)) ([5b0c3c3](https://github.com/waku-org/js-waku/commit/5b0c3c3cac3ddb5687d8f59457d6056527a8666c))
-
+- Compliance test for peer-exchange discovery ([#1186](https://github.com/waku-org/js-waku/issues/1186)) ([5b0c3c3](https://github.com/waku-org/js-waku/commit/5b0c3c3cac3ddb5687d8f59457d6056527a8666c))
 
 ### Bug Fixes
 
-* @waku/peer-exchange uses @waku/core and should depend on it ([e922ed4](https://github.com/waku-org/js-waku/commit/e922ed49ec70553227751518251152c765efd07c))
-
+- @waku/peer-exchange uses @waku/core and should depend on it ([e922ed4](https://github.com/waku-org/js-waku/commit/e922ed49ec70553227751518251152c765efd07c))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/core bumped from * to 0.0.12
-    * @waku/enr bumped from 0.0.6 to 0.0.7
-  * devDependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/core bumped from \* to 0.0.12
+    - @waku/enr bumped from 0.0.6 to 0.0.7
+  - devDependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.4](https://github.com/waku-org/js-waku/compare/peer-exchange-v0.0.3...peer-exchange-v0.0.4) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* directly convert from ENR to `PeerInfo`, remove unneeded utility
-* extract decoder code
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- directly convert from ENR to `PeerInfo`, remove unneeded utility
+- extract decoder code
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
-
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- DNS discovery as default bootstrap discovery ([#1114](https://github.com/waku-org/js-waku/issues/1114)) ([11819fc](https://github.com/waku-org/js-waku/commit/11819fc7b14e18385d421facaf2af0832cad1da8))
 
 ### Bug Fixes
 
-* **dns-discovery/peer-exchange:** Check if peer is already tagged ([952aadd](https://github.com/waku-org/js-waku/commit/952aadd7bbbe1a7265c5126c1678f552bef0648d))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- **dns-discovery/peer-exchange:** Check if peer is already tagged ([952aadd](https://github.com/waku-org/js-waku/commit/952aadd7bbbe1a7265c5126c1678f552bef0648d))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
-* Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
-
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
+- Extract decoder code ([130c49b](https://github.com/waku-org/js-waku/commit/130c49b636807063364f309da0da2a24a68f2178))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/enr bumped from * to 0.0.6
-    * @waku/proto bumped from * to 0.0.3
-  * devDependencies
-    * @waku/interfaces bumped from * to 0.0.8
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/enr bumped from \* to 0.0.6
+    - @waku/proto bumped from \* to 0.0.3
+  - devDependencies
+    - @waku/interfaces bumped from \* to 0.0.8
 
 ## Changelog
 

--- a/packages/proto/CHANGELOG.md
+++ b/packages/proto/CHANGELOG.md
@@ -2,40 +2,36 @@
 
 ## [0.0.4](https://github.com/waku-org/js-waku/compare/proto-v0.0.3...proto-v0.0.4) (2023-03-24)
 
-
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ## [0.0.3](https://github.com/waku-org/js-waku/compare/proto-v0.0.2...proto-v0.0.3) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* enable encoding of `meta` field
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* bump protons from 5.1.0 to 7.0.2
-* bump typescript
-* bump all prod dependencies
+- enable encoding of `meta` field
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- bump protons from 5.1.0 to 7.0.2
+- bump typescript
+- bump all prod dependencies
 
 ### Features
 
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
 
 ### Miscellaneous Chores
 
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump protons from 5.1.0 to 7.0.2 ([2f2d266](https://github.com/waku-org/js-waku/commit/2f2d266e8180cd1e7b89a7e261a33f87acce6ed2))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump protons from 5.1.0 to 7.0.2 ([2f2d266](https://github.com/waku-org/js-waku/commit/2f2d266e8180cd1e7b89a7e261a33f87acce6ed2))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ## Changelog
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,32 +2,29 @@
 
 ## [0.0.3](https://github.com/waku-org/js-waku/compare/utils-v0.0.2...utils-v0.0.3) (2023-03-24)
 
-
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ## [0.0.2](https://github.com/waku-org/js-waku/compare/utils-v0.0.1...utils-v0.0.2) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* directly convert from ENR to `PeerInfo`, remove unneeded utility
-* bump typescript
-* bump libp2p dependencies
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- directly convert from ENR to `PeerInfo`, remove unneeded utility
+- bump typescript
+- bump libp2p dependencies
 
 ### Bug Fixes
 
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Directly convert from ENR to `PeerInfo`, remove unneeded utility ([6dbcde0](https://github.com/waku-org/js-waku/commit/6dbcde041ab8fa8c2df75cc25319a0eccf6b0454))
 
 ## Changelog
 


### PR DESCRIPTION
## Problem

Some commits were pushed to `master` containing code against the `eslint` guidelines set in the repo.
It was caught when I merged `master` into a working branch and tried to make a commit; the precommit hook failed. Specifically `eslint`.

## Solution

This PR aims to resolve the above statement eslint errors introduced.

Root cause TBC. Tracking here: https://github.com/waku-org/js-waku/issues/1281

