### PR TITLE
chore: move build-utils to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30978,7 +30978,6 @@
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^6.1.0",
         "@noble/hashes": "^1.3.0",
-        "@waku/build-utils": "*",
         "@waku/core": "0.0.18",
         "@waku/interfaces": "0.0.13",
         "@waku/proto": "*",
@@ -30991,6 +30990,7 @@
         "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
+        "@waku/build-utils": "*",
         "rollup": "^3.15.0",
         "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "^6.1.0",
     "@noble/hashes": "^1.3.0",
-    "@waku/build-utils": "*",
     "@waku/core": "0.0.18",
     "@waku/interfaces": "0.0.13",
     "@waku/proto": "*",
@@ -62,6 +61,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.1.0",
+    "@waku/build-utils": "*",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "rollup": "^3.15.0",


### PR DESCRIPTION
## Problem

`@waku/relay` has `build-utils` as a `dependency` which during installation of peer packages that rely on `relay` were trying to install `build-utils` which is a dev-only package.

```
% npm i --save @waku/create           
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@waku%2fbuild-utils - Not found
npm ERR! 404 
npm ERR! 404  '@waku/build-utils@*' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/attila/.npm/_logs/2023-05-24T14_16_35_687Z-debug-0.log
```

## Solution

Move `build-utils` to `devDepdenencies`

## Notes

- related to https://discord.com/channels/864066763682218004/865466694554484738/1110934752862666934
- ideally to be a followed up with a release as certain current releases will not work as expected 🙏 cc @weboko 
