### PR TITLE
feat: disable libp2p autodial

### DIFF
--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -166,6 +166,7 @@ export class ConnectionManager {
 
   async dropConnection(peerId: PeerId): Promise<void> {
     try {
+      this.keepAliveManager.stop(peerId);
       await this.libp2p.hangUp(peerId);
       log(`Dropped connection with peer ${peerId.toString()}`);
     } catch (error) {

--- a/packages/sdk/src/create.ts
+++ b/packages/sdk/src/create.ts
@@ -164,6 +164,9 @@ export async function defaultLibp2p(
     : {};
 
   return createLibp2p({
+    connectionManager: {
+      minConnections: 1,
+    },
     transports: [webSockets({ filter: filterAll })],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()],


### PR DESCRIPTION
## Problem

Libp2p, with the upgrade, changed some config/API around toggling auto dials.

Libp2p autodials all discovered peers/peers that exist in the peerStore, until the `minConnections` limit is hit which means no cap on bootstrap peers. 

## Solution

Since we want a max cap on the number of bootstrap peers we want to connect to, we need to change the `minConnections` down to 1 without any recurring connection/drop off (which is currently happening as libp2p auto dials, our connection manager drops off, and this is repeated)

Reference: https://github.com/libp2p/js-libp2p/blob/7debe0312f6df68e27dc26410a745c98477abe59/doc/migrations/v0.42-v0.43.md?plain=1#L88

