### PR TITLE
chore: refactor peer-exchange compliance test

### DIFF
--- a/packages/tests/tests/peer_exchange.node.spec.ts
+++ b/packages/tests/tests/peer_exchange.node.spec.ts
@@ -4,7 +4,6 @@ import {
   PeerExchangeCodec,
   PeerExchangeDiscovery,
   WakuPeerExchange,
-  wakuPeerExchangeDiscovery,
 } from "@waku/peer-exchange";
 import { createLightNode, Libp2pComponents } from "@waku/sdk";
 import { expect } from "chai";
@@ -114,21 +113,13 @@ describe("Peer Exchange", () => {
           discv5BootstrapNode: enr,
         });
 
-        waku = await createLightNode({
-          libp2p: {
-            peerDiscovery: [wakuPeerExchangeDiscovery()],
-          },
-        });
-        const peerExchange = waku.libp2p.components["components"][
-          "peer-discovery-0"
-        ] as PeerExchangeDiscovery;
-
+        waku = await createLightNode();
         await waku.start();
-        const nwaku2Ma = await nwaku2.getMultiaddrWithId();
 
+        const nwaku2Ma = await nwaku2.getMultiaddrWithId();
         await waku.libp2p.dialProtocol(nwaku2Ma, PeerExchangeCodec);
 
-        return peerExchange;
+        return new PeerExchangeDiscovery(waku.libp2p.components);
       },
       teardown: async () => {
         await nwaku1?.stop();


### PR DESCRIPTION
## Problem

We have noticed some inconsistencies during the run of the peer-exchange compliance test in the CI. This was often fixed by a simple re-run, but was not reliable.
Ref: https://github.com/waku-org/js-waku/issues/1431#issuecomment-1663786788

Upon looking at the compliance test from the context of unreliable run times, I noticed that we were initialising the js-waku node **with** the peer-exchange discovery. However, the discovery should be **run** by the compliance test, and not by us.

## Solution

This PR refactors the compliance test setup by not mounting the peer-exchange discovery during the initialisation, and simply lets the test itself take care of it.

Steps that are now being performed during the test:
- start 2 nwaku nodes with PX enabled
- init and start js-waku node
- dial one of the two nwaku nodes
- handoff test to `@libp2p/interface-peer-discovery-compliance-tests`: this is where the PX discovery is now mounted and tests are performed

