### PR TITLE
chore: bump nwaku to 0.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
   node:
     runs-on: ubuntu-latest
     env:
-      WAKUNODE_IMAGE: "statusteam/nim-waku:v0.18.0"
+      WAKUNODE_IMAGE: "statusteam/nim-waku:v0.19.0"
     steps:
       - uses: actions/checkout@v3
 
@@ -88,7 +88,7 @@ jobs:
   node_optional:
     runs-on: ubuntu-latest
     env:
-      WAKUNODE_IMAGE: "statusteam/nim-waku:v0.18.0"
+      WAKUNODE_IMAGE: "statusteam/nim-waku:v0.19.0"
     steps:
       - uses: actions/checkout@v3
 

--- a/packages/tests/src/node/node.ts
+++ b/packages/tests/src/node/node.ts
@@ -27,7 +27,7 @@ const WAKU_SERVICE_NODE_PARAMS =
 const NODE_READY_LOG_LINE = "Node setup complete";
 
 const DOCKER_IMAGE_NAME =
-  process.env.WAKUNODE_IMAGE || "statusteam/nim-waku:v0.18.0";
+  process.env.WAKUNODE_IMAGE || "statusteam/nim-waku:v0.19.0";
 
 const isGoWaku = DOCKER_IMAGE_NAME.includes("go-waku");
 

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -4,7 +4,7 @@ import { promisify } from "util";
 const execAsync = promisify(exec);
 
 const WAKUNODE_IMAGE =
-  process.env.WAKUNODE_IMAGE || "statusteam/nim-waku:v0.18.0";
+  process.env.WAKUNODE_IMAGE || "statusteam/nim-waku:v0.19.0";
 
 async function main() {
   try {


### PR DESCRIPTION
This PR bumps up the version of nwaku to 0.19.0 for our CI & tests