### PR TITLE
chore: disable trailing commas from prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,12 @@
   ],
   "globals": { "BigInt": true, "console": true, "WebAssembly": true },
   "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "trailingComma": "none"
+      }
+    ],
     "comma-dangle": ["error", "never"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",


### PR DESCRIPTION
## Problem

There was a recent change in prettier which resulted in enabling trailing commas in the default config (which we used) which conflicts with our eslint config

## Solution

Add a rule to our prettier config to avoid trailing commas

## Notes

ref: https://github.com/waku-org/js-waku/issues/1483