### PR TITLE
chore: upgrade engine to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27519,7 +27519,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
@@ -27564,7 +27564,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/enr": {
@@ -27604,7 +27604,7 @@
         "uint8arrays": "^4.0.4"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/interfaces": {
@@ -27619,7 +27619,7 @@
         "npm-run-all": "^4.1.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/message-encryption": {
@@ -27656,7 +27656,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/message-hash": {
@@ -27692,7 +27692,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/peer-exchange": {
@@ -27723,7 +27723,7 @@
         "uint8arraylist": "^2.4.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/proto": {
@@ -27745,7 +27745,7 @@
         "uint8arraylist": "^2.4.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/relay": {
@@ -27771,7 +27771,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/sdk": {
@@ -27802,7 +27802,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/tests": {
@@ -27847,7 +27847,7 @@
         "npm-run-all": "^4.1.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/utils": {
@@ -27870,7 +27870,7 @@
         "rollup": "^3.29.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "packages/utils/node_modules/@waku/interfaces": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",

--- a/packages/dns-discovery/package.json
+++ b/packages/dns-discovery/package.json
@@ -48,7 +48,7 @@
     "test:browser": "karma start karma.conf.cjs"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@waku/enr": "0.0.17",

--- a/packages/enr/package.json
+++ b/packages/enr/package.json
@@ -48,7 +48,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@ethersproject/rlp": "^5.7.0",

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -44,7 +44,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "devDependencies": {
     "@chainsafe/libp2p-gossipsub": "^10.1.0",

--- a/packages/message-encryption/package.json
+++ b/packages/message-encryption/package.json
@@ -65,7 +65,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "browser": {
     "crypto": false

--- a/packages/message-hash/package.json
+++ b/packages/message-hash/package.json
@@ -47,7 +47,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",

--- a/packages/peer-exchange/package.json
+++ b/packages/peer-exchange/package.json
@@ -45,7 +45,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@libp2p/interfaces": "^3.3.2",

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -41,7 +41,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "protons-runtime": "^5.0.2"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -46,7 +46,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "^10.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,7 +45,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@chainsafe/libp2p-noise": "^13.0.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -47,7 +47,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@libp2p/interface-compliance-tests": "^4.0.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -62,7 +62,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
With the deprecation of nodejs 16, we should upgrade our engine to use 18 at a minimum

https://nodejs.org/en/blog/announcements/nodejs16-eol