### PR TITLE
fix(store)!: use `pubSubTopic` from `DecodedMessage` for `createCursor`

### DIFF
--- a/packages/core/src/lib/store/index.ts
+++ b/packages/core/src/lib/store/index.ts
@@ -247,7 +247,10 @@ class Store extends BaseProtocol implements IStore {
     ensurePubsubTopicIsConfigured(pubSubTopicForQuery, this.pubSubTopics);
 
     // check that the pubSubTopic from the Cursor and Decoder match
-    if (options?.cursor?.pubsubTopic !== pubSubTopicForQuery) {
+    if (
+      options?.cursor?.pubsubTopic &&
+      options.cursor.pubsubTopic !== pubSubTopicForQuery
+    ) {
       throw new Error(
         `Cursor pubsub topic (${options?.cursor?.pubsubTopic}) does not match decoder pubsub topic (${pubSubTopicForQuery})`
       );


### PR DESCRIPTION
## Problem

For Store protocol, `DecodedMessage`/`Decoder` as well as `createCursor` take in `pubSubTopic` while only the former is treated as the source of truth when using it.

## Solution

Since `DecodedMessage` now always has `PubSubTopic`, we can abstract away setting it from the API to library consumers.

