### PR TITLE
chore: revert logger namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,14 @@ jobs:
     with:
       nim_wakunode_image: wakuorg/go-waku:latest
       test_type: go-waku-master
-      debug: js-waku*
+      debug: waku*
 
   node_with_nwaku_master:
     uses: ./.github/workflows/test-node.yml
     with:
       nim_wakunode_image: wakuorg/nwaku:deploy-wakuv2-test
       test_type: nwaku-master
-      debug: js-waku*
+      debug: waku*
 
   maybe-release:
     name: release

--- a/packages/utils/src/logger/index.ts
+++ b/packages/utils/src/logger/index.ts
@@ -1,6 +1,6 @@
 import debug, { Debugger } from "debug";
 
-const APP_NAME = "js-waku";
+const APP_NAME = "waku";
 
 export class Logger {
   private _info: Debugger;


### PR DESCRIPTION
This PR reverts the `APP_NAME` change done in #1677 from `waku` to `js-waku`.
This change unnecessary introduced a breaking change for library consumers, while insignificant.

cc @fbarbu15 can you please confirm that this revert works as expected?
