### PR TITLE
fix: bootstrapping with default pubsub topic

### DIFF
--- a/packages/discovery/src/dns/dns.spec.ts
+++ b/packages/discovery/src/dns/dns.spec.ts
@@ -275,7 +275,7 @@ describe("DNS Node Discovery [live data]", function () {
     this.timeout(10000);
     // Google's dns server address. Needs to be set explicitly to run in CI
     const dnsNodeDiscovery = await DnsNodeDiscovery.dnsOverHttp();
-    const peers = await dnsNodeDiscovery.getPeers([enrTree.TWN_TEST], {
+    const peers = await dnsNodeDiscovery.getPeers([enrTree.TEST], {
       relay: maxQuantity,
       store: maxQuantity,
       filter: maxQuantity,
@@ -298,7 +298,7 @@ describe("DNS Node Discovery [live data]", function () {
     this.timeout(10000);
     // Google's dns server address. Needs to be set explicitly to run in CI
     const dnsNodeDiscovery = await DnsNodeDiscovery.dnsOverHttp();
-    const peers = await dnsNodeDiscovery.getPeers([enrTree.TWN_SANDBOX], {
+    const peers = await dnsNodeDiscovery.getPeers([enrTree.SANDBOX], {
       relay: maxQuantity,
       store: maxQuantity,
       filter: maxQuantity,

--- a/packages/tests/tests/dns-peer-discovery.spec.ts
+++ b/packages/tests/tests/dns-peer-discovery.spec.ts
@@ -33,7 +33,7 @@ describe("DNS Discovery: Compliance Test", function () {
       } as unknown as Libp2pComponents;
 
       return new PeerDiscoveryDns(components, {
-        enrUrls: [enrTree["TWN_SANDBOX"]],
+        enrUrls: [enrTree["SANDBOX"]],
         wantedNodeCapabilityCount: {
           filter: 1
         }
@@ -66,7 +66,7 @@ describe("DNS Node Discovery [live data]", function () {
     const waku = await createLightNode({
       libp2p: {
         peerDiscovery: [
-          wakuDnsDiscovery([enrTree["TWN_SANDBOX"]], nodeRequirements)
+          wakuDnsDiscovery([enrTree["SANDBOX"]], nodeRequirements)
         ]
       }
     });
@@ -93,7 +93,7 @@ describe("DNS Node Discovery [live data]", function () {
     // Google's dns server address. Needs to be set explicitly to run in CI
     const dnsNodeDiscovery = await DnsNodeDiscovery.dnsOverHttp();
 
-    const peers = await dnsNodeDiscovery.getPeers([enrTree["TWN_SANDBOX"]], {
+    const peers = await dnsNodeDiscovery.getPeers([enrTree["SANDBOX"]], {
       relay: maxQuantity,
       store: maxQuantity,
       filter: maxQuantity,
@@ -120,7 +120,7 @@ describe("DNS Node Discovery [live data]", function () {
     const waku = await createLightNode({
       libp2p: {
         peerDiscovery: [
-          wakuDnsDiscovery([enrTree["TWN_SANDBOX"], enrTree["TWN_TEST"]], {
+          wakuDnsDiscovery([enrTree["SANDBOX"], enrTree["TEST"]], {
             filter: nodesToConnect
           })
         ]

--- a/packages/tests/tests/waku.node.optional.spec.ts
+++ b/packages/tests/tests/waku.node.optional.spec.ts
@@ -37,7 +37,7 @@ describe("Use static and several ENR trees for bootstrap", function () {
         peerDiscovery: [
           bootstrap({ list: [multiAddrWithId.toString()] }),
           wakuDnsDiscovery(
-            [enrTree["TWN_SANDBOX"], enrTree["TWN_TEST"]],
+            [enrTree["SANDBOX"], enrTree["TEST"]],
             NODE_REQUIREMENTS
           )
         ]


### PR DESCRIPTION
## Problem

#2011 

## Solution

Use the `wakuv2.prod` fleet to bootstrap into `DefaultPubsubTopic`
https://discord.com/channels/1110799176264056863/1236947977252110346

## Notes

- [x] adds a TODO for support to The Waku Network fleet 
- Resolves #2011
