### PR TITLE
chore: upgrade nwaku to 0.29.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,14 @@ jobs:
     uses: ./.github/workflows/test-node.yml
     secrets: inherit
     with:
-      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.27.0' }}
+      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.29.0' }}
       test_type: node
       allure_reports: true
 
   node_optional:
     uses: ./.github/workflows/test-node.yml
     with:
-      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.27.0' }}
+      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.29.0' }}
       test_type: node-optional
 
   node_with_nwaku_master:

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -27,7 +27,7 @@ const WAKU_SERVICE_NODE_PARAMS =
 const NODE_READY_LOG_LINE = "Node setup complete";
 
 export const DOCKER_IMAGE_NAME =
-  process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
+  process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.29.0";
 
 const isGoWaku = DOCKER_IMAGE_NAME.includes("go-waku");
 

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -3,7 +3,7 @@ import { promisify } from "util";
 
 const execAsync = promisify(exec);
 
-const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
+const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.29.0";
 
 async function main() {
   try {

--- a/packages/tests/src/sync-rln-tree.js
+++ b/packages/tests/src/sync-rln-tree.js
@@ -7,7 +7,7 @@ import { ServiceNode } from "../dist/lib/service_node.js";
 
 const execAsync = promisify(exec);
 
-const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
+const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.29.0";
 const containerName = "rln_tree";
 
 async function syncRlnTree() {


### PR DESCRIPTION
This PR upgrades the default version for nwaku from 0.27.0 to 0.29.0

