### PR TITLE
chore(peer-exchange): use an event listener to gauge if the service is mounted

### DIFF
--- a/packages/discovery/src/peer-exchange/waku_peer_exchange_discovery.ts
+++ b/packages/discovery/src/peer-exchange/waku_peer_exchange_discovery.ts
@@ -51,7 +51,7 @@ export interface Options {
 }
 
 interface CustomDiscoveryEvent extends PeerDiscoveryEvents {
-  status: CustomEvent<boolean>;
+  "waku:peer-exchange:started": CustomEvent<boolean>;
 }
 
 export const DEFAULT_PEER_EXCHANGE_TAG_NAME = Tags.PEER_EXCHANGE;
@@ -106,7 +106,9 @@ export class PeerExchangeDiscovery
       return;
     }
 
-    this.dispatchEvent(new CustomEvent("isStarted", { detail: true }));
+    this.dispatchEvent(
+      new CustomEvent("waku:peer-exchange:started", { detail: true })
+    );
 
     log.info("Starting peer exchange node discovery, discovering peers");
 
@@ -129,7 +131,6 @@ export class PeerExchangeDiscovery
       "peer:identify",
       this.handleDiscoveredPeer
     );
-    this.dispatchEvent(new CustomEvent("isStarted", { detail: false }));
   }
 
   public get [symbol](): true {

--- a/packages/tests/tests/peer-exchange/compliance.spec.ts
+++ b/packages/tests/tests/peer-exchange/compliance.spec.ts
@@ -52,7 +52,7 @@ describe("Peer Exchange", function () {
           pubsubTopic
         );
 
-        peerExchange.addEventListener("isStarted", (event) => {
+        peerExchange.addEventListener("waku:peer-exchange:started", (event) => {
           if (event.detail === true) {
             void waku.libp2p.dialProtocol(nwaku2Ma, PeerExchangeCodec);
           }


### PR DESCRIPTION
## Problem

As mentioned in https://github.com/waku-org/js-waku/issues/2010, we currently hackily wait to dial peers as a means to gauge when the Peer Exchange discovery is mounted/started.
This brings flakiness and unreliability into the test suite, particularly so for [nwaku interop](https://github.com/waku-org/nwaku/issues/2621)

## Solution

Introduce an event listener for Peer Exchange discovery that can be used to gauge when the discovery service is started.
Also updates the compliance test to use this API


## Notes

- Resolves https://github.com/waku-org/js-waku/issues/2010 and https://github.com/waku-org/nwaku/issues/2621


Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
