### PR TITLE
fix(sds): initialize lamport timestamp with current time

### DIFF
--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -95,7 +95,9 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     super();
     this.channelId = channelId;
     this.senderId = senderId;
-    this.lamportTimestamp = 0;
+    // SDS RFC says to use nanoseconds, but current time in nanosecond is > Number.MAX_SAFE_INTEGER
+    // So instead we are using milliseconds and proposing a spec change (TODO)
+    this.lamportTimestamp = Date.now();
     this.filter = new DefaultBloomFilter(DEFAULT_BLOOM_FILTER_OPTIONS);
     this.outgoingBuffer = [];
     this.possibleAcks = new Map();


### PR DESCRIPTION
### Problem / Description

[SDS spec](https://github.com/vacp2p/rfc-index/blob/main/vac/raw/sds.md) states that the `lamportTimestamp` of a channel should be initialized with the current time in nanoseconds.

### Solution

Note that this is not viable in JS, so we initialized in milliseconds - See https://github.com/vacp2p/rfc-index/pull/179

### Notes

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
