### PR TITLE
feat!: remove version from decoder

### DIFF
--- a/packages/browser-tests/tests/server.spec.ts
+++ b/packages/browser-tests/tests/server.spec.ts
@@ -536,7 +536,6 @@ test.describe("Waku Server API", () => {
     expect(message).toHaveProperty("payload");
     expect(message).toHaveProperty("contentTopic");
     expect(message).toHaveProperty("timestamp");
-    expect(message).toHaveProperty("version");
 
     // Test pagination
     const paginatedResponse = await axios.get(

--- a/packages/browser-tests/tests/server.spec.ts
+++ b/packages/browser-tests/tests/server.spec.ts
@@ -326,7 +326,7 @@ test.describe("Waku Server API", () => {
 
           // If we get a 404, the route is not registered
           expect(response.status).not.toBe(404);
-        } catch (error) {
+        } catch (error: any) {
           console.warn(`Error checking endpoint ${endpoint}:`, error.message);
           // Continue checking other endpoints even if one fails
         }

--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -23,7 +23,7 @@ const testRoutingInfo = createRoutingInfo(testNetworkConfig, {
   contentTopic: testContentTopic
 });
 
-describe("Waku Message version 0", function () {
+describe("Waku Message", function () {
   it("Round trip binary serialization", async function () {
     await fc.assert(
       fc.asyncProperty(fc.uint8Array({ minLength: 1 }), async (payload) => {
@@ -41,7 +41,6 @@ describe("Waku Message version 0", function () {
 
         expect(result.contentTopic).to.eq(testContentTopic);
         expect(result.pubsubTopic).to.eq(testRoutingInfo.pubsubTopic);
-        expect(result.version).to.eq(0);
         expect(result.ephemeral).to.be.false;
         expect(result.payload).to.deep.eq(payload);
         expect(result.timestamp).to.not.be.undefined;

--- a/packages/core/src/lib/message/version_0.ts
+++ b/packages/core/src/lib/message/version_0.ts
@@ -76,12 +76,6 @@ export class DecodedMessage implements IDecodedMessage {
     return this.proto.meta;
   }
 
-  public get version(): number {
-    // https://rfc.vac.dev/spec/14/
-    // > If omitted, the value SHOULD be interpreted as version 0.
-    return this.proto.version ?? Version;
-  }
-
   public get rateLimitProof(): IRateLimitProof | undefined {
     return this.proto.rateLimitProof;
   }

--- a/packages/core/src/lib/message/version_0.ts
+++ b/packages/core/src/lib/message/version_0.ts
@@ -11,12 +11,10 @@ import type {
   PubsubTopic
 } from "@waku/interfaces";
 import { proto_message as proto } from "@waku/proto";
-import { Logger } from "@waku/utils";
 import { bytesToHex } from "@waku/utils/bytes";
 
 import { messageHash } from "../message_hash/index.js";
 
-const log = new Logger("message:version-0");
 const OneMillion = BigInt(1_000_000);
 
 export const Version = 0;
@@ -175,18 +173,6 @@ export class Decoder implements IDecoder<IDecodedMessage> {
     pubsubTopic: string,
     proto: IProtoMessage
   ): Promise<IDecodedMessage | undefined> {
-    // https://rfc.vac.dev/spec/14/
-    // > If omitted, the value SHOULD be interpreted as version 0.
-    if (proto.version ?? 0 !== Version) {
-      log.error(
-        "Failed to decode due to incorrect version, expected:",
-        Version,
-        ", actual:",
-        proto.version
-      );
-      return Promise.resolve(undefined);
-    }
-
     return new DecodedMessage(pubsubTopic, proto);
   }
 }

--- a/packages/core/src/lib/to_proto_message.spec.ts
+++ b/packages/core/src/lib/to_proto_message.spec.ts
@@ -17,7 +17,6 @@ describe("to proto message", () => {
     const keys = Object.keys(protoMessage);
     expect(keys).to.contain("payload");
     expect(keys).to.contain("contentTopic");
-    expect(keys).to.contain("version");
     expect(keys).to.contain("timestamp");
     expect(keys).to.contain("rateLimitProof");
     expect(keys).to.contain("ephemeral");

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -12,7 +12,6 @@ export interface IRateLimitProof {
 }
 
 export interface IDecodedMessage {
-  version: number;
   payload: Uint8Array;
   contentTopic: ContentTopic;
   pubsubTopic: PubsubTopic;

--- a/packages/message-encryption/src/ecies.spec.ts
+++ b/packages/message-encryption/src/ecies.spec.ts
@@ -47,7 +47,6 @@ describe("Ecies Encryption", function () {
 
           expect(result.contentTopic).to.equal(testContentTopic);
           expect(result.pubsubTopic).to.equal(testRoutingInfo.pubsubTopic);
-          expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.be.undefined;
           expect(result.verifySignature(new Uint8Array())).to.be.false;
@@ -92,7 +91,6 @@ describe("Ecies Encryption", function () {
 
           expect(result.contentTopic).to.equal(testContentTopic);
           expect(result.pubsubTopic).to.equal(testRoutingInfo.pubsubTopic);
-          expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.not.be.undefined;
           expect(result.verifySignature(alicePublicKey)).to.be.true;

--- a/packages/message-encryption/src/ecies.ts
+++ b/packages/message-encryption/src/ecies.ts
@@ -137,16 +137,6 @@ class Decoder extends DecoderV0 implements IDecoder<IEncryptedMessage> {
   ): Promise<IEncryptedMessage | undefined> {
     const cipherPayload = protoMessage.payload;
 
-    if (protoMessage.version !== Version) {
-      log.error(
-        "Failed to decrypt due to incorrect version, expected:",
-        Version,
-        ", actual:",
-        protoMessage.version
-      );
-      return;
-    }
-
     let payload;
 
     try {

--- a/packages/message-encryption/src/symmetric.spec.ts
+++ b/packages/message-encryption/src/symmetric.spec.ts
@@ -44,7 +44,6 @@ describe("Symmetric Encryption", function () {
 
           expect(result.contentTopic).to.equal(testContentTopic);
           expect(result.pubsubTopic).to.equal(testRoutingInfo.pubsubTopic);
-          expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.be.undefined;
           expect(result.verifySignature(new Uint8Array())).to.be.false;
@@ -86,7 +85,6 @@ describe("Symmetric Encryption", function () {
 
           expect(result.contentTopic).to.equal(testContentTopic);
           expect(result.pubsubTopic).to.equal(testRoutingInfo.pubsubTopic);
-          expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.not.be.undefined;
           expect(result.verifySignature(sigPubKey)).to.be.true;

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -137,16 +137,6 @@ class Decoder extends DecoderV0 implements IDecoder<IEncryptedMessage> {
   ): Promise<IEncryptedMessage | undefined> {
     const cipherPayload = protoMessage.payload;
 
-    if (protoMessage.version !== Version) {
-      log.error(
-        "Failed to decrypt due to incorrect version, expected:",
-        Version,
-        ", actual:",
-        protoMessage.version
-      );
-      return;
-    }
-
     let payload;
 
     try {

--- a/packages/rln/src/codec.spec.ts
+++ b/packages/rln/src/codec.spec.ts
@@ -63,7 +63,7 @@ describe("RLN codec with version 0", () => {
       protoResult!
     ))!;
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 0, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 
   it("toProtoObj", async function () {
@@ -92,7 +92,7 @@ describe("RLN codec with version 0", () => {
       proto!
     )) as RlnMessage<IDecodedMessage>;
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 0, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 });
 
@@ -131,7 +131,7 @@ describe("RLN codec with version 1", () => {
       protoResult!
     ))!;
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 1, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 
   it("Symmetric, toProtoObj", async function () {
@@ -166,7 +166,7 @@ describe("RLN codec with version 1", () => {
       proto!
     );
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 1, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 
   it("Asymmetric, toWire", async function () {
@@ -204,7 +204,7 @@ describe("RLN codec with version 1", () => {
       protoResult!
     ))!;
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 1, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 
   it("Asymmetric, toProtoObj", async function () {
@@ -240,7 +240,7 @@ describe("RLN codec with version 1", () => {
       proto!
     );
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 1, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 });
 
@@ -277,7 +277,7 @@ describe("RLN Codec - epoch", () => {
     expect(msg.epoch!.toString(10).length).to.eq(9);
     expect(msg.epoch).to.eq(epoch);
 
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 0, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 });
 
@@ -321,7 +321,7 @@ describe("RLN codec with version 0 and meta setter", () => {
     });
 
     expect(msg!.meta).to.deep.eq(expectedMeta);
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 0, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 
   it("toProtoObj", async function () {
@@ -358,6 +358,6 @@ describe("RLN codec with version 0 and meta setter", () => {
     });
 
     expect(msg!.meta).to.deep.eq(expectedMeta);
-    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, 0, rlnInstance);
+    verifyRLNMessage(msg, payload, TEST_CONSTANTS.contentTopic, rlnInstance);
   });
 });

--- a/packages/rln/src/codec.test-utils.ts
+++ b/packages/rln/src/codec.test-utils.ts
@@ -72,7 +72,6 @@ export function verifyRLNMessage(
   msg: any,
   payload: Uint8Array,
   contentTopic: string,
-  version: number,
   rlnInstance: any
 ): void {
   expect(msg.rateLimitProof).to.not.be.undefined;
@@ -82,7 +81,6 @@ export function verifyRLNMessage(
   expect(msg.epoch).to.be.gt(0);
 
   expect(msg.contentTopic).to.eq(contentTopic);
-  expect(msg.msg.version).to.eq(version);
   expect(msg.payload).to.deep.eq(payload);
   expect(msg.timestamp).to.not.be.undefined;
 }

--- a/packages/sdk/src/query_on_connect/query_on_connect.spec.ts
+++ b/packages/sdk/src/query_on_connect/query_on_connect.spec.ts
@@ -67,7 +67,6 @@ describe("QueryOnConnect", () => {
       (async function* () {
         yield [
           Promise.resolve({
-            version: 1,
             timestamp: new Date(),
             contentTopic: "/test/1/content",
             pubsubTopic: "/waku/2/default-waku/proto",
@@ -255,7 +254,6 @@ describe("QueryOnConnect", () => {
       const mockMessage: IDecodedMessage = {
         hash: new Uint8Array(),
         hashStr: "",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/1/content",
         pubsubTopic: "/waku/2/default-waku/proto",
@@ -501,7 +499,6 @@ describe("QueryOnConnect", () => {
       const mockMessage: IDecodedMessage = {
         hash: utf8ToBytes("1234"),
         hashStr: "1234",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/offline/content",
         pubsubTopic: "/waku/2/default-waku/proto",
@@ -535,7 +532,6 @@ describe("QueryOnConnect", () => {
       const mockMessage: IDecodedMessage = {
         hash: new Uint8Array(),
         hashStr: "1234",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/offline/content",
         pubsubTopic: "/waku/2/default-waku/proto",
@@ -579,7 +575,6 @@ describe("QueryOnConnect", () => {
       const mockMessage: IDecodedMessage = {
         hash: new Uint8Array(),
         hashStr: "",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/timeout/content",
         pubsubTopic: "/waku/2/default-waku/proto",
@@ -632,7 +627,6 @@ describe("QueryOnConnect", () => {
       const mockMessage1: IDecodedMessage = {
         hash: new Uint8Array(),
         hashStr: "",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/multi/content1",
         pubsubTopic: "/waku/2/default-waku/proto",
@@ -645,7 +639,6 @@ describe("QueryOnConnect", () => {
       const mockMessage2: IDecodedMessage = {
         hash: new Uint8Array(),
         hashStr: "",
-        version: 1,
         timestamp: new Date(),
         contentTopic: "/test/multi/content2",
         pubsubTopic: "/waku/2/default-waku/proto",

--- a/packages/sdk/src/reliable_channel/reliable_channel.spec.ts
+++ b/packages/sdk/src/reliable_channel/reliable_channel.spec.ts
@@ -531,7 +531,6 @@ describe("Reliable Channel", () => {
       const autoRetrievedMessage: IDecodedMessage = {
         hash: hexToBytes("1234"),
         hashStr: "1234",
-        version: 1,
         timestamp: new Date(),
         contentTopic: TEST_CONTENT_TOPIC,
         pubsubTopic: decoder.pubsubTopic,
@@ -609,7 +608,6 @@ describe("Reliable Channel", () => {
       const autoRetrievedMessage1: IDecodedMessage = {
         hash: hexToBytes("5678"),
         hashStr: "5678",
-        version: 1,
         timestamp: new Date(Date.now() - 1000),
         contentTopic: TEST_CONTENT_TOPIC,
         pubsubTopic: decoder.pubsubTopic,
@@ -622,7 +620,6 @@ describe("Reliable Channel", () => {
       const autoRetrievedMessage2: IDecodedMessage = {
         hash: hexToBytes("9abc"),
         hashStr: "9abc",
-        version: 1,
         timestamp: new Date(),
         contentTopic: TEST_CONTENT_TOPIC,
         pubsubTopic: decoder.pubsubTopic,

--- a/packages/sdk/src/reliable_channel/reliable_channel.ts
+++ b/packages/sdk/src/reliable_channel/reliable_channel.ts
@@ -430,7 +430,6 @@ export class ReliableChannel<
         payload: sdsMessage.content,
         hash: msg.hash,
         hashStr: msg.hashStr,
-        version: msg.version,
         contentTopic: msg.contentTopic,
         pubsubTopic: msg.pubsubTopic,
         timestamp: msg.timestamp,

--- a/packages/sdk/src/store/store.spec.ts
+++ b/packages/sdk/src/store/store.spec.ts
@@ -70,7 +70,6 @@ describe("Store", () => {
     };
 
     const mockMessage: IDecodedMessage = {
-      version: 1,
       pubsubTopic: "/waku/2/default-waku/proto",
       contentTopic: "/test/1/test/proto",
       payload: new Uint8Array([1, 2, 3]),

--- a/packages/tests/src/lib/message_collector.ts
+++ b/packages/tests/src/lib/message_collector.ts
@@ -171,13 +171,6 @@ export class MessageCollector {
       `Message content topic mismatch. Expected: ${options.expectedContentTopic}. Got: ${message.contentTopic}`
     );
 
-    expect(message.version).to.eq(
-      options.expectedVersion || 0,
-      `Message version mismatch. Expected: ${
-        options.expectedVersion || 0
-      }. Got: ${message.version}`
-    );
-
     if (message.ephemeral !== undefined) {
       expect(message.ephemeral).to.eq(
         options.expectedEphemeral !== undefined

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -60,7 +60,6 @@ export interface MessageRpcQuery {
 export interface MessageRpcResponse {
   payload: string;
   contentTopic?: string;
-  version?: number;
   timestamp?: bigint; // Unix epoch time in nanoseconds as a 64-bits integer value.
   ephemeral?: boolean;
 }

--- a/packages/tests/tests/relay/interop.node.spec.ts
+++ b/packages/tests/tests/relay/interop.node.spec.ts
@@ -70,7 +70,6 @@ describe("Waku Relay, Interop", function () {
     }
 
     expect(msgs[0].contentTopic).to.equal(TestContentTopic);
-    expect(msgs[0].version).to.equal(0);
     expect(base64ToUtf8(msgs[0].payload)).to.equal(messageText);
   });
 
@@ -99,7 +98,6 @@ describe("Waku Relay, Interop", function () {
     const receivedMsg = await receivedMsgPromise;
 
     expect(receivedMsg.contentTopic).to.eq(TestContentTopic);
-    expect(receivedMsg.version!).to.eq(0);
     expect(bytesToUtf8(receivedMsg.payload!)).to.eq(messageText);
   });
 


### PR DESCRIPTION
### Problem / Description

`version` is used to store payload encryption information. It is actually useless:

- developer should attempt to decrypt messages based on usage of content topic
- failed decryption is cheap

And mixes up routing concern (`Waku Message`) with application concerns (payload encryption).

### Solution

Stop reading `version` from messages in a phased removal.

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves
- Related to

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
