### PR TITLE
chore: expose sdk from waku/react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,4 @@
+export * from "@waku/sdk";
+
 export type { CreateNodeOptions } from "./types.js";
 export { WakuProvider, useWaku } from "./WakuProvider.js";


### PR DESCRIPTION
### Problem / Description
We need to expose waku/sdk from waku/react to remove the need to have both of the packages on consumer side.

### Solution
Expose it.

### Notes
- Resolves https://github.com/waku-org/js-waku/issues/2675
