### PR TITLE
feat: add dialTimeout, change dialingQueue to Map

### DIFF
--- a/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
+++ b/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
@@ -65,7 +65,8 @@ describe("ConnectionLimiter", () => {
     enableAutoRecovery: true,
     maxDialingPeers: 3,
     failedDialCooldown: 60,
-    dialCooldown: 10
+    dialCooldown: 10,
+    dialTimeout: 30
   };
 
   function createLimiter(

--- a/packages/core/src/lib/connection_manager/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager/connection_manager.ts
@@ -29,6 +29,7 @@ const DEFAULT_MAX_CONNECTIONS = 10;
 const DEFAULT_MAX_DIALING_PEERS = 3;
 const DEFAULT_FAILED_DIAL_COOLDOWN_SEC = 60;
 const DEFAULT_DIAL_COOLDOWN_SEC = 10;
+const DEFAULT_DIAL_TIMEOUT_SEC = 30;
 
 type ConnectionManagerConstructorOptions = {
   libp2p: Libp2p;
@@ -61,6 +62,7 @@ export class ConnectionManager implements IConnectionManager {
       maxDialingPeers: DEFAULT_MAX_DIALING_PEERS,
       failedDialCooldown: DEFAULT_FAILED_DIAL_COOLDOWN_SEC,
       dialCooldown: DEFAULT_DIAL_COOLDOWN_SEC,
+      dialTimeout: DEFAULT_DIAL_TIMEOUT_SEC,
       ...options.config
     };
 

--- a/packages/core/src/lib/connection_manager/dialer.spec.ts
+++ b/packages/core/src/lib/connection_manager/dialer.spec.ts
@@ -39,6 +39,7 @@ describe("Dialer", () => {
       maxDialingPeers: 3,
       failedDialCooldown: 60,
       dialCooldown: 10,
+      dialTimeout: 30,
       maxConnections: 10,
       enableAutoRecovery: true
     };

--- a/packages/interfaces/src/connection_manager.ts
+++ b/packages/interfaces/src/connection_manager.ts
@@ -74,6 +74,13 @@ export type ConnectionManagerOptions = {
    * @default 10 seconds
    */
   dialCooldown: number;
+
+  /**
+   * Time to wait for a dial attempt to complete before timing out.
+   *
+   * @default 30 seconds
+   */
+  dialTimeout: number;
 };
 
 export interface IConnectionManager {


### PR DESCRIPTION
### Problem / Description

The dialer can become permanently stuck, preventing light nodes from maintaining stable peer connections. Two critical issues:

1. **Dialer deadlock**: When `libp2p.dial()` hangs indefinitely (due to DNS resolution stalls or unresponsive WebSocket handshakes), the dialer's `isProcessing` flag remains true forever, stopping all future dial attempts. This was observed in production where the dialer stopped processing after ~1 hour of operation.

2. **Duplicate peers in queue**: The same peers are repeatedly added to the dial queue because the Array-based queue doesn't prevent duplicates. This causes the dialer to waste attempts on the same small set of peers instead of trying new ones.

These issues compound over time, leading to connection degradation (e.g., 4 peers → 3 → 2 → 1 → 0) with no recovery, requiring a full restart.

### Solution

**1. Add configurable dial timeout** (prevents deadlock)
- Wrap `libp2p.dial()` in `Promise.race()` with a 30-second timeout (configurable via `dialTimeout` option)
- If a dial attempt exceeds the timeout, it's aborted and the peer is marked as failed
- The dialer can continue processing other peers instead of hanging forever

**2. Replace Array queue with Map** (prevents duplicates)
- Changed `dialingQueue` from `PeerId[]` to `Map<string, PeerId>`
- Map uses `peerId.toString()` as key, automatically deduplicating entries

**Design decisions:**
- Kept timeout configurable (default 30s) to allow tuning based on network conditions
- Map-based queue is a drop-in replacement with identical iteration order

### Notes

**Testing in production:**
- Ran modified version continuously for 12+ hours with stable 4-peer connections
- Previously, unmodified version would deadlock within few hours
- Queue size remained stable (0-10 peers) vs. growing to 4,000+ before the fix

**Trade-offs:**
- 30-second timeout may abort legitimate slow connections, but this is preferable to indefinite hangs. Users can increase `dialTimeout` if needed.
- Map uses slightly more memory than Array, but the difference is negligible for typical peer counts.

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible. (Tested in production environment for 12+ hours)
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.