### PR TITLE
fix: dead link for waku v2 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # js-waku
 
-A TypeScript implementation of the [Waku v2 protocol](https://lip.logos.co/messaging/standards/core/10/waku2.html).
+A TypeScript implementation of the [Waku v2 protocol](https://lip.logos.co/messaging/core/draft/10/waku2.html).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # js-waku
 
-A TypeScript implementation of the [Waku v2 protocol](https://rfc.vac.dev/spec/10/).
+A TypeScript implementation of the [Waku v2 protocol](https://lip.logos.co/messaging/standards/core/10/waku2.html).
 
 ## Documentation
 


### PR DESCRIPTION
### Problem / Description
https://rfc.vac.dev/spec/10/ is a dead link

### Solution
replace it w/ https://lip.logos.co/messaging/core/draft/10/waku2.html

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves
- Related to

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
